### PR TITLE
fix bug with falsy values in parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
 'use strict';
 
+function isEmpty(value) {
+  switch (typeof value) {
+    case 'string':
+      return !value.length;
+    case 'number':
+      return false;
+    default:
+      return !value;
+  }
+}
+
 function getRequestOptions(endpoint, fixture, baseUrl) {
   fixture.url = fixture.url || fixture.path;
   fixture.request = fixture.request || fixture.args;
@@ -15,8 +26,8 @@ function getRequestOptions(endpoint, fixture, baseUrl) {
   (endpoint.parameters || []).forEach(function (param) {
     var value = fixture.request[param.name];
 
-    if (param.required && !value) throw new Error('No required request field ' + param.name + ' for ' + fixture.method.toUpperCase() + ' ' + fixture.url);
-    if (!value) return;
+    if (param.required && isEmpty(value)) throw new Error('No required request field ' + param.name + ' for ' + fixture.method.toUpperCase() + ' ' + fixture.url);
+    if (isEmpty(value)) return;
 
     switch (param.in) {
       case 'body':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-request-by-swagger",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Constructs request.js options from swagger endpoint",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-request-by-swagger",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "description": "Constructs request.js options from swagger endpoint",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -28,5 +28,42 @@ describe('build options by endpoint', () => {
       done();
     });
   });
+
+  it('get with non-empty, falsy parameter', () => {
+    const path = '/pet/{petId}';
+    const endpoint = schema.paths[path].post;
+    const args = {
+      petId: 0
+    };
+    const options = {
+      method: 'get',
+      baseUrl: `http://${schema.host}${schema.basePath}`,
+      path: path,
+      args: args,
+    };
+    requestOptions = getRequestOptions(endpoint, options);
+    assert.equal(requestOptions.url, 'http://petstore.swagger.io/v2/pet/0');
+  });
+
+  it('get with empty, falsy parameter', () => {
+    const path = '/pet/{petId}';
+    const endpoint = schema.paths[path].post;
+    const args = {
+      petId: ''
+    };
+    const options = {
+      method: 'get',
+      baseUrl: `http://${schema.host}${schema.basePath}`,
+      path: path,
+      args: args,
+    };
+    try {
+      requestOptions = getRequestOptions(endpoint, options);
+    } catch (e) {
+      assert.equal(e.message, 'No required request field petId for GET /pet/{petId}')
+    }
+
+  });
+
 });
 


### PR DESCRIPTION
I've discovered a bug in handling parameter values which are `falsy` like `0`.
