### PR TITLE
Fix passing request headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,12 @@ function getRequestOptions(endpoint, fixture, baseUrl) {
         }
         reqOpts.qs[param.name] = newValue;
         break;
-      case 'headers':
+      case 'header':
         if (!reqOpts.headers) reqOpts.headers = {};
         reqOpts.headers[param.name] = value;
         break;
+      default:
+        throw new Error(`Unsupported param type for param ${param.name}: ${param.in}`)
     }
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,11 +5,11 @@ const request = require('request');
 let requestOptions;
 
 describe('build options by endpoint', () => {
-  it('body json', () => {
+  it('should add request body to request options', () => {
     const path = '/pet';
     const endpoint = schema.paths[path].post;
     const args = {
-      body: {name: 'test'}
+      body: { name: 'test' }
     };
     const options = {
       method: 'post',
@@ -18,14 +18,40 @@ describe('build options by endpoint', () => {
       args: args,
     };
     requestOptions = getRequestOptions(endpoint, options);
-    assert.equal(requestOptions.url, 'http://petstore.swagger.io/v2/pet');
-    assert.deepEqual(requestOptions.body, { name: 'test' });
+    assert.deepEqual(requestOptions, {
+      url: 'http://petstore.swagger.io/v2/pet',
+      method: 'post',
+      headers: { 'Content-type': 'application/json' },
+      body: { name: 'test' } });
   });
 
-  it('test with request', (done) => {
-    console.log(requestOptions);
+  it('should generate valid request options', (done) => {
     request(requestOptions, (err, data) => {
       done();
+    });
+  });
+
+  it('should add request headers to request options', () => {
+    const path = '/pet/{petId}';
+    const endpoint = schema.paths[path].delete;
+    const args = {
+      petId: 'mock-pet-id',
+      api_key: 'mock api key'
+    };
+    const options = {
+      method: 'delete',
+      baseUrl: `http://${schema.host}${schema.basePath}`,
+      path: path,
+      args: args,
+    };
+    requestOptions = getRequestOptions(endpoint, options);
+    assert.deepEqual(requestOptions, {
+      url: 'http://petstore.swagger.io/v2/pet/mock-pet-id',
+      method: 'delete',
+      headers: {
+        'Content-type': 'application/json',
+        api_key: 'mock api key'
+      }
     });
   });
 });


### PR DESCRIPTION
There was a typo in param type it was `headers` instead of `header` this pr
fixes the issues and adds a test.