### PR TITLE
allow explicitly passed empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ function getRequestOptions(endpoint, fixture, baseUrl, schemaParameters) {
 
     var value = fixture.request[param.name];
 
-    if (param.required && !value) throw new Error('No required request field ' + param.name + ' for ' + fixture.method.toUpperCase() + ' ' + fixture.url);
-    if (!value) return;
+    if (param.required && !value && value !== '') throw new Error('No required request field ' + param.name + ' for ' + fixture.method.toUpperCase() + ' ' + fixture.url);
+    if (!value && value !== '') return;
 
     switch (param.in) {
       case 'body':

--- a/test/index.js
+++ b/test/index.js
@@ -54,5 +54,29 @@ describe('build options by endpoint', () => {
       }
     });
   });
+
+  it('should allow empty strings', () => {
+    const path = '/pet/{petId}';
+    const endpoint = schema.paths[path].delete;
+    const args = {
+      petId: '',
+      api_key: 'mock api key'
+    };
+    const options = {
+      method: 'delete',
+      baseUrl: `http://${schema.host}${schema.basePath}`,
+      path: path,
+      args: args,
+    };
+    requestOptions = getRequestOptions(endpoint, options, null, schema.parameters);
+    assert.deepEqual(requestOptions, {
+      url: 'http://petstore.swagger.io/v2/pet/',
+      method: 'delete',
+      headers: {
+        'Content-type': 'application/json',
+        api_key: 'mock api key'
+      }
+    });
+  });
 });
 


### PR DESCRIPTION
If you explicitly pass an empty string, that is a valid string. Not passing any string should be what triggers an error.